### PR TITLE
Add automated test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "package.json"
   ],
   "scripts": {
+    "lint": "eslint src; eslint test",
     "dist": "babel -d lib src",
-    "lint": "eslint src"
+    "test-only": "mocha --recursive --reporter spec test/**/*.spec.js",
+    "test": "npm run lint && npm run dist && npm run test-only"
   },
   "repository": {
     "type": "git",
@@ -42,7 +44,9 @@
   "devDependencies": {
     "babel": "^5.8.21",
     "babel-eslint": "^4.0.10",
+    "chai": "^3.5.0",
     "core-js": "^1.1.1",
-    "eslint": "^1.8.0"
+    "eslint": "^1.8.0",
+    "mocha": "^3.2.0"
   }
 }

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const { assert } = require('chai');
+const { parse } = require('../lib/index.js');
+
+describe('parse', function() {
+  function test(scenario) {
+    let requirement = scenario.skip ? it.skip : it;
+    requirement(`${JSON.stringify(scenario.s)} -> ${JSON.stringify(scenario.expectations)}`, function() {
+      let actual = parse(scenario.s);
+      assert.equal(actual.size, scenario.size, 'size should match');
+      Object.keys(scenario.expectations).forEach(propertyName => {
+        assert.equal(actual.get(propertyName), scenario.expectations[propertyName]);
+      });
+    });
+  }
+
+  describe('Falsey', function() {
+    [{
+      s: '',
+      size: 0,
+      expectations: {}
+    }, {
+      s: 'invalid',
+      size: 1,
+      expectations: {}
+    }].forEach(test);
+  });
+
+  describe('Basic', function() {
+    [{
+      s: 'CN=Simple',
+      size: 1,
+      expectations: {
+        CN: 'Simple'
+      }
+    }, {
+      s: 'CN=Name with spaces',
+      size: 1,
+      expectations: {
+        CN: 'Name with spaces'
+      }
+    }, {
+      s: 'CN=Steve Kille,O=Isode Limited,C=GB',
+      size: 3,
+      expectations: {
+        CN: 'Steve Kille',
+        O: 'Isode Limited',
+        C: 'GB'
+      }
+    }, {
+      s: 'CN=marshall.t.rose@example.com, O=Dover Beach Consulting, L=Santa Clara,ST=California, C=US',
+      size: 5,
+      expectations: {
+        CN: 'marshall.t.rose@example.com',
+        O: 'Dover Beach Consulting',
+        L: 'Santa Clara',
+        ST: 'California',
+        C: 'US'
+      }
+    }].forEach(test);
+  });
+
+  describe('Quoted', function() {
+    [{
+      s: 'CN="Quoted name"',
+      size: 1,
+      expectations: {
+        CN: 'Quoted name'
+      }
+    }, {
+      s: 'CN=" Leading and trailing spaces "',
+      size: 1,
+      expectations: {
+        CN: ' Leading and trailing spaces '
+      }
+    }, {
+      s: 'CN="Comma, inside"',
+      size: 1,
+      expectations: {
+        CN: 'Comma, inside'
+      }
+    }, {
+      s: 'CN="Crazy !@#$%&*()<>[]{},.?/\\| mess"',
+      size: 1,
+      expectations: {
+        CN: 'Crazy !@#$%&*()<>[]{},.?/\\| mess'
+      }
+    }].forEach(test);
+  });
+
+  describe('Escaped', function() {
+    [{
+      skip: true,
+      s: 'CN=Trailing space\ ',
+      size: 1,
+      expectations: {
+          CN: 'Trailing space ',
+      }
+    }, {
+      skip: true,
+      s: 'CN="Quotation \\" mark"',
+      size: 1,
+      expectations: {
+        CN: 'Quotation " mark'
+      }
+    }].forEach(test);
+  });
+
+  describe('Multi-valued', function() {
+    [{
+      skip: true,
+      s: 'OU=Sales+CN=J. Smith,O=Widget Inc.,C=US',
+      size: 3,
+      expectations: {
+        OU: 'Sales',
+        '+CN': 'J. Smith',  // FIXME: Is this the expected behavior??
+        O: 'Widget Inc.',
+        C: 'US'
+      }
+    }].forEach(test);
+  });
+});


### PR DESCRIPTION
I think it would be very helpful to be able to see how the parser handles various inputs as this (1) helps avoid regression bugs when making changes and (2) helps users know what the expect.

Run `npm install` then `npm run test` to build the project, run tests, and see resulting report like the one below:
```
  parse
    Falsey
      ✓ "" -> {}
      ✓ "invalid" -> {}
    Basic
      ✓ "CN=Simple" -> {"CN":"Simple"}
      ✓ "CN=Name with spaces" -> {"CN":"Name with spaces"}
      ✓ "CN=Steve Kille,O=Isode Limited,C=GB" -> {"CN":"Steve Kille","O":"Isode Limited","C":"GB"}
      ✓ "CN=marshall.t.rose@example.com, O=Dover Beach Consulting, L=Santa Clara,ST=California, C=US" -> {"CN":"marshall.t.rose@example.com","O":"Dover Beach Consulting","L":"Santa Clara","ST":"California","C":"US"}
    Quoted
      ✓ "CN=\"Quoted name\"" -> {"CN":"Quoted name"}
      ✓ "CN=\" Leading and trailing spaces \"" -> {"CN":" Leading and trailing spaces "}
      ✓ "CN=\"Comma, inside\"" -> {"CN":"Comma, inside"}
      ✓ "CN=\"Crazy !@#$%&*()<>[]{},.?/\\| mess\"" -> {"CN":"Crazy !@#$%&*()<>[]{},.?/\\| mess"}
    Escaped
      - "CN=Trailing space " -> {"CN":"Trailing space "}
      - "CN=\"Quotation \\\" mark\"" -> {"CN":"Quotation \" mark"}
    Multi-valued
      - "OU=Sales+CN=J. Smith,O=Widget Inc.,C=US" -> {"OU":"Sales","+CN":"J. Smith","O":"Widget Inc.","C":"US"}


  10 passing (6ms)
  3 pending
```