### PR TITLE
Feature/get all

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ Looks up the given key and returns all values.
 
 ```js
 let dn = rfc2253.parse('CN=Wayne\\, Bruce,DC=Wayne Enterprises,DC=com,OU=Research and Development,OU=Gadget Services');
-dn.get('OU'); // ['Research and Development', 'Gadget Services']
-dn.get('DC'); // ['Wayne Enterprises', 'com']
+dn.getAll('OU'); // ['Research and Development', 'Gadget Services']
+dn.getAll('DC'); // ['Wayne Enterprises', 'com']
 ```
 
 ### set

--- a/README.md
+++ b/README.md
@@ -147,6 +147,24 @@ let rdn = dn.get(0); // <RelativeDistinguishedName>
 rdn.get('CN'); // 'Wayne, Bruce'
 ```
 
+### getAll
+
+Looks up the given key and returns all values.
+
+**Arguments**
+
+* **key**: *string*
+
+  The key in at least one RDN.
+
+**Examples**
+
+```js
+let dn = rfc2253.parse('CN=Wayne\\, Bruce,DC=Wayne Enterprises,DC=com,OU=Research and Development,OU=Gadget Services');
+dn.get('OU'); // ['Research and Development', 'Gadget Services']
+dn.get('DC'); // ['Wayne Enterprises', 'com']
+```
+
 ### set
 
 Sets the given offset to the given `RelativeDistinguishedName` or sets the given key to the given value.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rfc2253",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "LDAPv3 Distinguished Name parser and formatter.",
   "main": "lib/index.js",
   "files": [

--- a/src/dn.js
+++ b/src/dn.js
@@ -19,6 +19,16 @@ export default class DistinguishedName {
       return this._rdns[i].get(key);
     }
   }
+  getAll(key) {
+    const results = [];
+    for (let i = 0; i < this._rdns.length; i++) {
+      if (!this._rdns[i].has(key)) continue;
+      const rdnValue = this._rdns[i].get(key);
+      if (results.includes(rdnValue)) continue;
+      results.push(rdnValue);
+    }
+    return results;
+  }
   set(key, value) {
     if (typeof key === 'number') {
       if (value instanceof RelativeDistinguishedName) {


### PR DESCRIPTION
This is a small convenience method that I've added to get all values for a given key. The case for it is as follows:

* A dn string contains multiple OUs, DCs, etc.
* There is a need to check for the existince of one or more OUs, DCs, etc.
* Rather than accessing the implied private property `_rdns` on the DistinguishedName class and iterating over it, provide a method that returns all values for a given key and iterate over that instead

I've provided an example in the README as part of my PR, and incremented the patch version